### PR TITLE
sys: use strstr() to detect installed packages

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -233,8 +233,7 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 			break;
 		case 'S':
 			if (is_field("Status", line))
-				if (sscanf(line, "Status: install %63s installed", tmp) == 1)
-					installed = true;
+				installed = !!strstr(line, " installed");
 			break;
 		default:
 			if (is_blank(line)) {


### PR DESCRIPTION
Don't rely on sscanf() doesn't care about unused suffixes of the status string. Use strstr() instead to make sure only actually installed packages are returned.

Suggested-by: @efahl
Reported-by: @efahl
Fixes: #6