### PR TITLE
Update iwinfo.c

### DIFF
--- a/iwinfo.c
+++ b/iwinfo.c
@@ -382,6 +382,7 @@ rpc_iwinfo_scan(struct ubus_context *ctx, struct ubus_object *obj,
 	void *c, *d, *t;
 	char mac[18];
 	char res[IWINFO_BUFSIZE];
+	memset(res, 0, sizeof(res));
 	struct iwinfo_scanlist_entry *e;
 
 	rv = rpc_iwinfo_open(msg);


### PR DESCRIPTION
The buffer `res` in `rpc_iwinfo_scan()` was previously uninitialized before being passed to `iw->scanlist()`. If the scan result was shorter than previous data, or not fully written, residual data could lead to garbage or incorrect output.

This patch adds an explicit `memset(res, 0, sizeof(res));` before the scan to ensure clean and consistent output, especially during repeated scans or partial data writes.

Tested on OpenWrt with multiple interface scans to confirm stability.