### PR TITLE
[24.10] rpc-sys: packagelist: don't truncate input lines on read

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -188,7 +188,7 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *tb[__RPC_PACKAGELIST_MAX];
 	bool all = false, installed = false, auto_installed = false;
 	struct blob_buf buf = { 0 };
-	char line[256], tmp[128], pkg[128], ver[128];
+	char line[512], tmp[128], pkg[128], ver[128];
 	char *pkg_abi;
 	void *tbl;
 


### PR DESCRIPTION
When the /usr/lib/opkg/status file is read during 'ubus call rpc-sys packagelist', long input lines are being truncated, which produces incorrect package lists.  The line read buffer is increased to 512, which should be able to handle the longest lines in the file.

The 512 value was arrived at by examining the status file on several devices.  The list of hostapd/wpad conflicts appears to have be longest line generated in opkg packages, but that second line of 259 characters containing the dependencies appears to be the actual root cause of the issues linked below.

Here are the three longest lines I found on all of my installations (actual output truncated):
```
$ awk '{print length(), $0}' /usr/lib/opkg/status  | sort -n
 ...
 188 Depends: kernel (= 6.6.93~35ef4dd36891d37023436baa842fa311-r1), ... kmod-lib-crc32c
 259 Depends: hostapd-common (= 2024.09.15~5ace39b0-r2), libc, ... libmbedtls21
 397 Conflicts: hostapd, hostapd-basic, hostapd-basic-openssl, ... wpad-basic-wolfssl
```
Suggested-by: @hlhintz
Fixes: https://github.com/efahl/owut/issues/28
Fixes: https://github.com/openwrt/rpcd/issues/16