### PR TITLE
rpc-sys: packagelist: handle ABI versions in apk world properly

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -318,10 +318,16 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 			break;
 		default:
 			if (is_blank(line)) {
-				if (pkg[0] && ver[0] && is_all_or_world(pkg, world)) {
-					if (abi[0])
+				if (pkg[0] && ver[0]) {
+					/* Need to check both ABI-versioned and non-versioned pkg */
+					bool keep = is_all_or_world(pkg, world);
+					if (abi[0]) {
 						pkg[strlen(pkg)-strlen(abi)] = '\0';
-					blobmsg_add_string(&buf, pkg, ver);
+						if (!keep)
+							keep = is_all_or_world(pkg, world);
+					}
+					if (keep)
+						blobmsg_add_string(&buf, pkg, ver);
 				}
 				abi[0] = pkg[0] = ver[0] = '\0';
 			}


### PR DESCRIPTION
It was originally assumed that all entries in '/etc/apk/world' would have ABI-versioned package names.  This turns out to be false, and apk happily adds package names with or without the ABI version suffix.  This causes the output from 'ubus call rpc-sys packagelist' to exclude some packages from the user-installed package list, thus causing them to disappear when doing an ASU build.

Fix it by checking both versioned and unversioned package names.

Link: https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/744
Fixes: https://github.com/efahl/owut/issues/49