### PR TITLE
exec: harden deferred reply teardown

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -122,6 +122,7 @@ rpc_exec_reply(struct rpc_exec_context *c, int rv)
 {
 	uloop_timeout_cancel(&c->timeout);
 	uloop_process_delete(&c->process);
+	c->timeout.cb = NULL;
 
 	if (rv == UBUS_STATUS_OK)
 	{
@@ -167,6 +168,10 @@ rpc_exec_reply_cb(struct uloop_timeout *t)
 static void
 rpc_exec_schedule_reply(struct rpc_exec_context *c, int rv)
 {
+	if (!c->timeout.cb ||
+	    (c->timeout.cb == rpc_exec_reply_cb && c->timeout.pending))
+		return;
+
 	c->deferred_status = rv;
 	c->timeout.cb = rpc_exec_reply_cb;
 	uloop_timeout_set(&c->timeout, 0);
@@ -318,6 +323,12 @@ rpc_exec(const char **args, rpc_exec_write_cb_t in,
 	if (!c)
 		return UBUS_STATUS_UNKNOWN_ERROR;
 
+	memset(c, 0, sizeof(*c));
+	if (blob_buf_init(&c->blob, 0) != 0) {
+		free(c);
+		return UBUS_STATUS_UNKNOWN_ERROR;
+	}
+
 	if (pipe(ipipe))
 		goto fail_ipipe;
 
@@ -350,9 +361,6 @@ rpc_exec(const char **args, rpc_exec_write_cb_t in,
 			return rpc_errno_status();
 
 	default:
-		memset(c, 0, sizeof(*c));
-		blob_buf_init(&c->blob, 0);
-
 		c->stdin_cb  = in;
 		c->stdout_cb = out;
 		c->stderr_cb = err;
@@ -402,6 +410,7 @@ fail_opipe:
 	close(ipipe[1]);
 
 fail_ipipe:
+	blob_buf_free(&c->blob);
 	free(c);
 	return rpc_errno_status();
 }

--- a/file.c
+++ b/file.c
@@ -789,6 +789,7 @@ rpc_file_exec_reply(struct rpc_file_exec_context *c, int rv)
 {
 	uloop_timeout_cancel(&c->timeout);
 	uloop_process_delete(&c->process);
+	c->timeout.cb = NULL;
 
 	if (rv == UBUS_STATUS_OK)
 	{
@@ -826,6 +827,10 @@ rpc_file_exec_reply_cb(struct uloop_timeout *t)
 static void
 rpc_file_exec_schedule_reply(struct rpc_file_exec_context *c, int rv)
 {
+	if (!c->timeout.cb ||
+	    (c->timeout.cb == rpc_file_exec_reply_cb && c->timeout.pending))
+		return;
+
 	c->deferred_status = rv;
 	c->timeout.cb = rpc_file_exec_reply_cb;
 	uloop_timeout_set(&c->timeout, 0);

--- a/plugin.c
+++ b/plugin.c
@@ -67,12 +67,16 @@ rpc_plugin_json_element_to_blob(const char *name, json_object *val,
 	switch (json_object_get_type(val)) {
 	case json_type_object:
 		c = blobmsg_open_table(blob, name);
+		if (!c)
+			return;
 		rpc_plugin_json_object_to_blob(val, blob);
 		blobmsg_close_table(blob, c);
 		break;
 
 	case json_type_array:
 		c = blobmsg_open_array(blob, name);
+		if (!c)
+			return;
 		rpc_plugin_json_array_to_blob(json_object_get_array(val), blob);
 		blobmsg_close_array(blob, c);
 		break;


### PR DESCRIPTION
Follow-up to #27.

The deferred async exec reply path can still schedule another zero-timeout reply once reply teardown has started. On current master this path reuses `c->timeout`, so leave teardown marked by clearing `timeout.cb` and keep the first pending deferred status while a reply callback is already queued.

Also initialize the exec reply blob buffer before pipe/fork cleanup paths and guard plugin JSON table/array allocation failures before closing or recursing into them.