### PR TITLE
Fix a series of security and correctness bugs

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -353,7 +353,7 @@ rpc_exec(const char **args, rpc_exec_write_cb_t in,
 		close(epipe[1]);
 
 		if (execv(cmd, (char * const *)args))
-			return rpc_errno_status();
+			_exit(127);
 
 	default:
 		memset(c, 0, sizeof(*c));

--- a/exec.c
+++ b/exec.c
@@ -196,6 +196,12 @@ rpc_exec_process_cb(struct uloop_process *p, int stat)
 	close(c->opipe.fd.fd);
 	close(c->epipe.fd.fd);
 
+	/* ustream_free() does not reset the fd, and rpc_exec_reply() closes it
+	 * again later.  Mark the descriptors as consumed so that the second
+	 * close() cannot accidentally close an unrelated, meanwhile reused fd. */
+	c->opipe.fd.fd = -1;
+	c->epipe.fd.fd = -1;
+
 	ustream_poll(&c->opipe.stream);
 	ustream_poll(&c->epipe.stream);
 }

--- a/file.c
+++ b/file.c
@@ -979,7 +979,7 @@ rpc_file_exec_run(const char *cmd, const struct blob_attr *sid,
 		devnull = open("/dev/null", O_RDWR);
 
 		if (devnull == -1)
-			return UBUS_STATUS_UNKNOWN_ERROR;
+			_exit(127);
 
 		dup2(devnull, 0);
 		dup2(opipe[1], 1);
@@ -995,7 +995,7 @@ rpc_file_exec_run(const char *cmd, const struct blob_attr *sid,
 		args = malloc(sizeof(char *) * arglen);
 
 		if (!args)
-			return UBUS_STATUS_UNKNOWN_ERROR;
+			_exit(127);
 
 		args[0] = (char *)executable;
 		args[1] = NULL;
@@ -1010,7 +1010,7 @@ rpc_file_exec_run(const char *cmd, const struct blob_attr *sid,
 				if (arglen == 255)
 				{
 					free(args);
-					return UBUS_STATUS_INVALID_ARGUMENT;
+					_exit(127);
 				}
 
 				arglen++;
@@ -1019,7 +1019,7 @@ rpc_file_exec_run(const char *cmd, const struct blob_attr *sid,
 				if (!tmp)
 				{
 					free(args);
-					return UBUS_STATUS_UNKNOWN_ERROR;
+					_exit(127);
 				}
 
 				args = tmp;
@@ -1040,7 +1040,7 @@ rpc_file_exec_run(const char *cmd, const struct blob_attr *sid,
 		}
 
 		if (execv(executable, args))
-			return rpc_errno_status();
+			_exit(127);
 
 	default:
 		memset(c, 0, sizeof(*c));

--- a/file.c
+++ b/file.c
@@ -414,7 +414,9 @@ rpc_file_write(struct ubus_context *ctx, struct ubus_object *obj,
 	if (fd < 0)
 		return rpc_errno_status();
 
-	if (tb[RPC_F_RW_BASE64] && blobmsg_get_bool(tb[RPC_F_RW_BASE64]))
+	/* data_len can be 0 for an empty "data" string; skip the decode in that
+	 * case since b64_decode() asserts on a zero destination size. */
+	if (data_len > 0 && tb[RPC_F_RW_BASE64] && blobmsg_get_bool(tb[RPC_F_RW_BASE64]))
 	{
 		data_len = b64_decode(data, data, data_len);
 		if (data_len < 0)

--- a/file.c
+++ b/file.c
@@ -579,8 +579,8 @@ rpc_file_list(struct ubus_context *ctx, struct ubus_object *obj,
 				tlen = readlink(entrypath, tbuf, sizeof(tbuf) - 1);
 				if (tlen >= 0) {
 					tbuf[tlen] = '\0';
+					blobmsg_add_string(&buf, "name", tbuf);
 				}
-				blobmsg_add_string(&buf, "name", tbuf);
 
 				struct stat target;
 				if (!stat(entrypath, &target)) {

--- a/iwinfo.c
+++ b/iwinfo.c
@@ -611,32 +611,37 @@ rpc_iwinfo_survey(struct ubus_context *ctx, struct ubus_object *obj,
 	void *c, *d;
 	int i, rv, len;
 
-	blob_buf_init(&buf, 0);
-
 	rv = rpc_iwinfo_open(msg);
+
+	if (rv)
+		return rv;
+
+	blob_buf_init(&buf, 0);
 
 	c = blobmsg_open_array(&buf, "results");
 
-	if (rv || iw->survey(ifname, res, &len) || len < 0)
-		return UBUS_STATUS_OK;
+	if (!iw->survey(ifname, res, &len) && (len > 0))
+	{
+		for (i = 0; i < len; i += sizeof(struct iwinfo_survey_entry)) {
+			e = (struct iwinfo_survey_entry *)&res[i];
 
-	for (i = 0; i < len; i += sizeof(struct iwinfo_survey_entry)) {
-		e = (struct iwinfo_survey_entry *)&res[i];
-
-		d = blobmsg_open_table(&buf, NULL);
-		blobmsg_add_u32(&buf, "mhz", e->mhz);
-		blobmsg_add_u32(&buf, "noise", e->noise);
-		blobmsg_add_u64(&buf, "active_time", e->active_time);
-		blobmsg_add_u64(&buf, "busy_time", e->busy_time);
-		blobmsg_add_u64(&buf, "busy_time_ext", e->busy_time_ext);
-		blobmsg_add_u64(&buf, "rx_time", e->rxtime);
-		blobmsg_add_u64(&buf, "tx_time", e->txtime);
-		blobmsg_close_table(&buf, d);
+			d = blobmsg_open_table(&buf, NULL);
+			blobmsg_add_u32(&buf, "mhz", e->mhz);
+			blobmsg_add_u32(&buf, "noise", e->noise);
+			blobmsg_add_u64(&buf, "active_time", e->active_time);
+			blobmsg_add_u64(&buf, "busy_time", e->busy_time);
+			blobmsg_add_u64(&buf, "busy_time_ext", e->busy_time_ext);
+			blobmsg_add_u64(&buf, "rx_time", e->rxtime);
+			blobmsg_add_u64(&buf, "tx_time", e->txtime);
+			blobmsg_close_table(&buf, d);
+		}
 	}
 
 	blobmsg_close_array(&buf, c);
 	ubus_send_reply(ctx, req, buf.head);
+
 	rpc_iwinfo_close();
+
 	return UBUS_STATUS_OK;
 }
 

--- a/iwinfo.c
+++ b/iwinfo.c
@@ -135,7 +135,7 @@ rpc_iwinfo_lower(const char *src, char *dst, size_t len)
 	size_t i;
 
 	for (i = 0; *src && i < len; i++)
-		*dst++ = tolower(*src++);
+		*dst++ = tolower((unsigned char)*src++);
 
 	*dst = 0;
 }

--- a/main.c
+++ b/main.c
@@ -79,9 +79,11 @@ int main(int argc, char **argv)
 			ubus_socket = optarg;
 			break;
 
-		case 't':
-			rpc_exec_timeout = 1000 * strtol(optarg, NULL, 0);
+		case 't': {
+			long t = strtol(optarg, NULL, 0);
+			rpc_exec_timeout = (t > 0 && t <= 600) ? (int)(t * 1000) : -1;
 			break;
+		}
 
 		default:
 			break;

--- a/plugin.c
+++ b/plugin.c
@@ -453,7 +453,7 @@ rpc_plugin_register_exec(struct ubus_context *ctx, const char *path)
 		close(fds[1]);
 
 		if (execl(path, path, "list", NULL))
-			return UBUS_STATUS_UNKNOWN_ERROR;
+			_exit(127);
 
 	default:
 		plugin = rpc_plugin_parse_exec(name + 1, fds[0]);

--- a/plugin.c
+++ b/plugin.c
@@ -23,6 +23,7 @@ static struct blob_buf buf;
 struct rpc_plugin_lookup_context {
 	uint32_t id;
 	char *name;
+	size_t namelen;
 	bool found;
 };
 
@@ -35,15 +36,15 @@ rpc_plugin_lookup_plugin_cb(struct ubus_context *ctx,
 	if (c->id == obj->id)
 	{
 		c->found = true;
-		sprintf(c->name, "%s", obj->path);
+		snprintf(c->name, c->namelen, "%s", obj->path);
 	}
 }
 
 static bool
 rpc_plugin_lookup_plugin(struct ubus_context *ctx, struct ubus_object *obj,
-                         char *strptr)
+                         char *strptr, size_t strsize)
 {
-	struct rpc_plugin_lookup_context c = { .id = obj->id, .name = strptr };
+	struct rpc_plugin_lookup_context c = { .id = obj->id, .name = strptr, .namelen = strsize };
 
 	if (ubus_lookup(ctx, NULL, rpc_plugin_lookup_plugin_cb, &c))
 		return false;
@@ -220,7 +221,8 @@ rpc_plugin_call(struct ubus_context *ctx, struct ubus_object *obj,
 
 	plugin = c->path + sprintf(c->path, "%s/", RPC_PLUGIN_DIRECTORY);
 
-	if (!rpc_plugin_lookup_plugin(ctx, obj, plugin))
+	if (!rpc_plugin_lookup_plugin(ctx, obj, plugin,
+	                              sizeof(c->path) - (plugin - c->path)))
 	{
 		rv = UBUS_STATUS_NOT_FOUND;
 		goto fail;

--- a/rc.c
+++ b/rc.c
@@ -109,6 +109,9 @@ static void rpc_list_exec_timeout_cb(struct uloop_timeout *t)
 
 	uloop_process_delete(&c->process);
 	kill(c->process.pid, SIGKILL);
+	/* uloop no longer tracks the process after uloop_process_delete(), so
+	 * reap the killed child here to avoid leaving a zombie behind. */
+	waitpid(c->process.pid, NULL, 0);
 
 	rc_list_readdir(c);
 }

--- a/rc.c
+++ b/rc.c
@@ -193,6 +193,7 @@ static void rc_list_readdir(struct rc_list_context *c)
 		closedir(c->dir);
 		ubus_send_reply(c->ctx, &c->req, c->buf->head);
 		ubus_complete_deferred_request(c->ctx, &c->req, UBUS_STATUS_OK);
+		free(c);
 		return;
 	}
 

--- a/rc.c
+++ b/rc.c
@@ -50,7 +50,7 @@ struct rc_list_context {
 	struct blob_buf *buf;
 	DIR *dir;
 	bool skip_running_check;
-	const char *req_name;
+	char *req_name;
 
 	/* Info about currently processed init.d entry */
 	struct {
@@ -193,6 +193,7 @@ static void rc_list_readdir(struct rc_list_context *c)
 		closedir(c->dir);
 		ubus_send_reply(c->ctx, &c->req, c->buf->head);
 		ubus_complete_deferred_request(c->ctx, &c->req, UBUS_STATUS_OK);
+		free(c->req_name);
 		free(c);
 		return;
 	}
@@ -283,8 +284,11 @@ static int rc_list(struct ubus_context *ctx, struct ubus_object *obj,
 	}
 	if (tb[RC_LIST_SKIP_RUNNING_CHECK])
 		c->skip_running_check = blobmsg_get_bool(tb[RC_LIST_SKIP_RUNNING_CHECK]);
+	/* Copy the requested name: msg (and the ctx receive buffer it points
+	 * into) is only valid during this call, but req_name is dereferenced
+	 * later from the deferred, asynchronous directory walk. */
 	if (tb[RC_LIST_NAME])
-		c->req_name = blobmsg_get_string(tb[RC_LIST_NAME]);
+		c->req_name = strdup(blobmsg_get_string(tb[RC_LIST_NAME]));
 
 	ubus_defer_request(ctx, req, &c->req);
 

--- a/rc.c
+++ b/rc.c
@@ -47,7 +47,7 @@ struct rc_list_context {
 	struct uloop_timeout timeout;
 	struct ubus_context *ctx;
 	struct ubus_request_data req;
-	struct blob_buf *buf;
+	struct blob_buf buf;
 	DIR *dir;
 	bool skip_running_check;
 	char *req_name;
@@ -88,17 +88,17 @@ static void rc_list_add_table(struct rc_list_context *c)
 {
 	void *e;
 
-	e = blobmsg_open_table(c->buf, c->entry.d_name);
+	e = blobmsg_open_table(&c->buf, c->entry.d_name);
 
 	if (c->entry.start >= 0)
-		blobmsg_add_u16(c->buf, "start", c->entry.start);
+		blobmsg_add_u16(&c->buf, "start", c->entry.start);
 	if (c->entry.stop >= 0)
-		blobmsg_add_u16(c->buf, "stop", c->entry.stop);
-	blobmsg_add_u8(c->buf, "enabled", c->entry.enabled);
+		blobmsg_add_u16(&c->buf, "stop", c->entry.stop);
+	blobmsg_add_u8(&c->buf, "enabled", c->entry.enabled);
 	if (!c->skip_running_check && c->entry.use_procd)
-		blobmsg_add_u8(c->buf, "running", c->entry.running);
+		blobmsg_add_u8(&c->buf, "running", c->entry.running);
 
-	blobmsg_close_table(c->buf, e);
+	blobmsg_close_table(&c->buf, e);
 }
 
 static void rpc_list_exec_timeout_cb(struct uloop_timeout *t)
@@ -191,8 +191,9 @@ static void rc_list_readdir(struct rc_list_context *c)
 	 */
 	if (!e || (c->req_name && c->entry.d_name)) {
 		closedir(c->dir);
-		ubus_send_reply(c->ctx, &c->req, c->buf->head);
+		ubus_send_reply(c->ctx, &c->req, c->buf.head);
 		ubus_complete_deferred_request(c->ctx, &c->req, UBUS_STATUS_OK);
+		blob_buf_free(&c->buf);
 		free(c->req_name);
 		free(c);
 		return;
@@ -264,24 +265,23 @@ static int rc_list(struct ubus_context *ctx, struct ubus_object *obj,
 		   struct blob_attr *msg)
 {
 	struct blob_attr *tb[__RC_LIST_MAX];
-	static struct blob_buf buf;
 	struct rc_list_context *c;
 
 	blobmsg_parse(rc_list_policy, __RC_LIST_MAX, tb, blobmsg_data(msg), blobmsg_data_len(msg));
-
-	blob_buf_init(&buf, 0);
 
 	c = calloc(1, sizeof(*c));
 	if (!c)
 		return UBUS_STATUS_UNKNOWN_ERROR;
 
 	c->ctx = ctx;
-	c->buf = &buf;
 	c->dir = opendir("/etc/init.d");
 	if (!c->dir) {
 		free(c);
 		return UBUS_STATUS_UNKNOWN_ERROR;
 	}
+
+	blob_buf_init(&c->buf, 0);
+
 	if (tb[RC_LIST_SKIP_RUNNING_CHECK])
 		c->skip_running_check = blobmsg_get_bool(tb[RC_LIST_SKIP_RUNNING_CHECK]);
 	/* Copy the requested name: msg (and the ctx receive buffer it points

--- a/session.c
+++ b/session.c
@@ -956,7 +956,7 @@ rpc_login_test_permission(struct uci_section *s,
 			if (!p || *p != '!')
 				continue;
 
-			while (isspace(*++p));
+			while (isspace((unsigned char)*++p));
 
 			if (!*p)
 				continue;
@@ -1224,7 +1224,7 @@ rpc_validate_sid(const char *id)
 		return false;
 
 	while (*id)
-		if (!isxdigit(*id++))
+		if (!isxdigit((unsigned char)*id++))
 			return false;
 
 	return true;

--- a/session.c
+++ b/session.c
@@ -152,7 +152,7 @@ rpc_random(char *dest)
 	unsigned char buf[16] = { 0 };
 	FILE *f;
 	int i;
-	int ret;
+	size_t ret;
 
 	f = fopen("/dev/urandom", "r");
 	if (!f)
@@ -161,8 +161,12 @@ rpc_random(char *dest)
 	ret = fread(buf, 1, sizeof(buf), f);
 	fclose(f);
 
-	if (ret < 0)
-		return ret;
+	/* fread() returns a size_t, so a short read can never be negative.
+	 * Require the full buffer to be filled, otherwise we would derive the
+	 * session id from (partially) uninitialized/zero data, resulting in a
+	 * predictable identifier. */
+	if (ret != sizeof(buf))
+		return -1;
 
 	for (i = 0; i < sizeof(buf); i++)
 		sprintf(dest + (i<<1), "%02x", buf[i]);

--- a/sys.c
+++ b/sys.c
@@ -327,8 +327,13 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 				if (pkg[0] && ver[0]) {
 					/* Need to check both ABI-versioned and non-versioned pkg */
 					bool keep = is_all_or_world(pkg, world);
-					if (abi[0]) {
-						pkg[strlen(pkg)-strlen(abi)] = '\0';
+					size_t plen = strlen(pkg), alen = strlen(abi);
+					/* The ABI version is expected to be a suffix of the
+					 * package name.  Guard against a malformed status file
+					 * where it is longer, which would underflow the
+					 * unsigned subtraction and write out of bounds. */
+					if (abi[0] && alen <= plen) {
+						pkg[plen - alen] = '\0';
 						if (!keep)
 							keep = is_all_or_world(pkg, world);
 					}

--- a/sys.c
+++ b/sys.c
@@ -191,7 +191,7 @@ static bool
 is_blank(const char *line)
 {
 	for (; *line; line++)
-		if (!isspace(*line))
+		if (!isspace((unsigned char)*line))
 			return false;
 	return true;
 }

--- a/sys.c
+++ b/sys.c
@@ -130,11 +130,11 @@ rpc_cgi_password_set(struct ubus_context *ctx, struct ubus_object *obj,
 
 		ret = chdir("/");
 		if (ret < 0)
-			return rpc_errno_status();
+			_exit(127);
 
 		if (execl(passwd, passwd,
 		          blobmsg_data(tb[RPC_P_USER]), NULL))
-			return rpc_errno_status();
+			_exit(127);
 
 	default:
 		close(fds[0]);

--- a/sys.c
+++ b/sys.c
@@ -237,11 +237,14 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 	if (!all) {
 		/* We return only those items appearing in 'world' file. */
 		int world_fd = open("/etc/apk/world", O_RDONLY);
-		if (world_fd == -1)
+		if (world_fd == -1) {
+			fclose(f);
 			return rpc_errno_status();
+		}
 
 		if (fstat(world_fd, &statbuf) == -1) {
 			close(world_fd);
+			fclose(f);
 			return rpc_errno_status();
 		}
 
@@ -249,18 +252,21 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 		if (world_mmap_size == 1) {
 			/* 'world' file is malformed: empty */
 			close(world_fd);
+			fclose(f);
 			return UBUS_STATUS_UNKNOWN_ERROR;
 		}
 
 		world_mmap = (char *)mmap(NULL, world_mmap_size, PROT_READ, MAP_PRIVATE, world_fd, 0);
 		close(world_fd);
 		if (world_mmap == MAP_FAILED) {
+			fclose(f);
 			return rpc_errno_status();
 		}
 
 		if (world_mmap[world_mmap_size-2] != '\n') {
 			/* 'world' file is malformed: missing final newline */
 			munmap(world_mmap, world_mmap_size);
+			fclose(f);
 			return UBUS_STATUS_UNKNOWN_ERROR;
 		}
 

--- a/sys.c
+++ b/sys.c
@@ -280,6 +280,11 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 		if (nstrs) {
 			/* extra one in world for NULL sentinel */
 			world = (const char **)calloc(nstrs+1, sizeof(char *));
+			if (!world) {
+				munmap(world_mmap, world_mmap_size);
+				fclose(f);
+				return UBUS_STATUS_UNKNOWN_ERROR;
+			}
 			world[0] = world_mmap;
 			for (istr = 1, s = world_mmap; *s; s++) {
 				if (*s == '\n') {

--- a/sys.c
+++ b/sys.c
@@ -18,7 +18,6 @@
 
 #include <stdbool.h>
 #include <libubus.h>
-#include <sys/mman.h>
 
 #include <rpcd/exec.h>
 #include <rpcd/plugin.h>
@@ -210,8 +209,8 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 	void *tbl;
 	struct stat statbuf;
 	const char **world = NULL;
-	char *world_mmap = NULL;
-	size_t world_mmap_size = 0;
+	char *world_buf = NULL;
+	size_t world_size = 0;
 	char *token = NULL;
 
 	/*
@@ -248,31 +247,58 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 			return rpc_errno_status();
 		}
 
-		world_mmap_size = statbuf.st_size + 1;
-		if (world_mmap_size == 1) {
+		world_size = statbuf.st_size + 1;
+		if (world_size == 1) {
 			/* 'world' file is malformed: empty */
 			close(world_fd);
 			fclose(f);
 			return UBUS_STATUS_UNKNOWN_ERROR;
 		}
 
-		world_mmap = (char *)mmap(NULL, world_mmap_size, PROT_READ, MAP_PRIVATE, world_fd, 0);
-		close(world_fd);
-		if (world_mmap == MAP_FAILED) {
+		/*
+		 * Read the whole file into a NUL terminated heap buffer.  The
+		 * parser below relies on C string termination (a trailing NUL at
+		 * world_buf[statbuf.st_size]); mmap() could not guarantee a
+		 * readable byte at that offset when the file size is an exact
+		 * multiple of the page size, which would fault with SIGBUS.
+		 */
+		world_buf = malloc(world_size);
+		if (!world_buf) {
+			close(world_fd);
 			fclose(f);
-			return rpc_errno_status();
+			return UBUS_STATUS_UNKNOWN_ERROR;
 		}
 
-		if (world_mmap[world_mmap_size-2] != '\n') {
+		size_t world_got = 0;
+		while (world_got < (size_t)statbuf.st_size) {
+			ssize_t rd = read(world_fd, world_buf + world_got,
+			                  statbuf.st_size - world_got);
+			if (rd < 0 && errno == EINTR)
+				continue;
+			if (rd <= 0)
+				break;
+			world_got += rd;
+		}
+		close(world_fd);
+
+		if (world_got != (size_t)statbuf.st_size) {
+			free(world_buf);
+			fclose(f);
+			return UBUS_STATUS_UNKNOWN_ERROR;
+		}
+
+		world_buf[statbuf.st_size] = '\0';
+
+		if (world_buf[world_size-2] != '\n') {
 			/* 'world' file is malformed: missing final newline */
-			munmap(world_mmap, world_mmap_size);
+			free(world_buf);
 			fclose(f);
 			return UBUS_STATUS_UNKNOWN_ERROR;
 		}
 
 		/* resulting 'world' pointer map looks like this:
-		 * nstrs = 2 == count of newlines in mmap
-		 * mmap  = "pkg1\npkg2=1.2\n\0"
+		 * nstrs = 2 == count of newlines in buffer
+		 * buf   = "pkg1\npkg2=1.2\n\0"
 		 *          |     |         |
 		 * world[0]-+     |         |
 		 * world[1]-------+         |
@@ -281,18 +307,18 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 
 		size_t istr, nstrs;
 		char *s;
-		for (nstrs = 0, s = world_mmap; s[nstrs]; s[nstrs] == '\n' ? nstrs++ : *s++);
+		for (nstrs = 0, s = world_buf; s[nstrs]; s[nstrs] == '\n' ? nstrs++ : *s++);
 
 		if (nstrs) {
 			/* extra one in world for NULL sentinel */
 			world = (const char **)calloc(nstrs+1, sizeof(char *));
 			if (!world) {
-				munmap(world_mmap, world_mmap_size);
+				free(world_buf);
 				fclose(f);
 				return UBUS_STATUS_UNKNOWN_ERROR;
 			}
-			world[0] = world_mmap;
-			for (istr = 1, s = world_mmap; *s; s++) {
+			world[0] = world_buf;
+			for (istr = 1, s = world_buf; *s; s++) {
 				if (*s == '\n') {
 					world[istr] = s + 1;
 					istr++;
@@ -354,8 +380,8 @@ rpc_sys_packagelist(struct ubus_context *ctx, struct ubus_object *obj,
 
 	if (world)
 		free(world);
-	if (world_mmap)
-		munmap(world_mmap, world_mmap_size);
+	if (world_buf)
+		free(world_buf);
 
 	blobmsg_close_table(&buf, tbl);
 	ubus_send_reply(ctx, req, buf.head);

--- a/uci.c
+++ b/uci.c
@@ -197,7 +197,7 @@ rpc_uci_verify_str(const char *name, bool extended, bool type)
 		extended = false;
 
 	for (c = name + extended; *c; c++)
-		if (!isalnum(*c) && *c != '_' && ((!type && !extended) || *c != '-'))
+		if (!isalnum((unsigned char)*c) && *c != '_' && ((!type && !extended) || *c != '-'))
 			break;
 
 	if (extended) {

--- a/uci.c
+++ b/uci.c
@@ -1635,8 +1635,14 @@ rpc_uci_apply(struct ubus_context *ctx, struct ubus_object *obj,
 		globfree(&gl);
 
 		if (rollback) {
+			/* Clamp to a sane range to avoid signed overflow of the
+			 * millisecond value for a large (or, via uint32 wraparound,
+			 * negative) client supplied timeout, which would otherwise
+			 * fire the rollback timer immediately. */
+			int msecs = (timeout > 0 && timeout <= INT_MAX / 1000)
+				? timeout * 1000 : INT_MAX;
 			apply_timer.cb = rpc_uci_apply_timeout;
-			uloop_timeout_set(&apply_timer, timeout * 1000);
+			uloop_timeout_set(&apply_timer, msecs);
 			apply_ctx = ctx;
 		}
 	}

--- a/ucode.c
+++ b/ucode.c
@@ -754,7 +754,7 @@ rpc_ucode_script_register(struct ubus_context *ctx, rpc_ucode_script_t *script)
 		uuobj->script = script;
 		uuobj->signature = ubus_object_methods;
 
-		snprintf(tnptr, typelen, "rpcd-plugin-ucode-%s", ubus_object_name);
+		snprintf(tnptr, typelen + 1, "rpcd-plugin-ucode-%s", ubus_object_name);
 
 		method = (struct ubus_method *)mptr;
 

--- a/ucode.c
+++ b/ucode.c
@@ -34,6 +34,11 @@
 
 #define RPC_UCSCRIPT_DIRECTORY INSTALL_PREFIX "/share/rpcd/ucode"
 
+/* Bound the recursion when converting a (client supplied) blob message into
+ * ucode values, so a deeply nested argument cannot overflow the stack. Real
+ * ubus messages never come anywhere near this depth. */
+#define RPC_UCODE_MAX_NESTING 32
+
 static struct blob_buf buf;
 static int request_timeout;
 
@@ -174,23 +179,28 @@ rpc_ucode_ucv_object_to_blob(uc_value_t *val, struct blob_buf *blob)
 }
 
 static uc_value_t *
-rpc_ucode_blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const char **name);
+rpc_ucode_blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const char **name, int depth);
 
 static uc_value_t *
-rpc_ucode_blob_array_to_ucv(uc_vm_t *vm, struct blob_attr *attr, size_t len, bool table)
+rpc_ucode_blob_array_to_ucv(uc_vm_t *vm, struct blob_attr *attr, size_t len, bool table, int depth)
 {
-	uc_value_t *o = table ? ucv_object_new(vm) : ucv_array_new(vm);
+	uc_value_t *o;
 	uc_value_t *v;
 	struct blob_attr *pos;
 	size_t rem = len;
 	const char *name;
+
+	if (depth > RPC_UCODE_MAX_NESTING)
+		return NULL;
+
+	o = table ? ucv_object_new(vm) : ucv_array_new(vm);
 
 	if (!o)
 		return NULL;
 
 	__blob_for_each_attr(pos, attr, rem) {
 		name = NULL;
-		v = rpc_ucode_blob_to_ucv(vm, pos, table, &name);
+		v = rpc_ucode_blob_to_ucv(vm, pos, table, &name, depth);
 
 		if (table && name)
 			ucv_object_add(o, name, v);
@@ -204,7 +214,7 @@ rpc_ucode_blob_array_to_ucv(uc_vm_t *vm, struct blob_attr *attr, size_t len, boo
 }
 
 static uc_value_t *
-rpc_ucode_blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const char **name)
+rpc_ucode_blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const char **name, int depth)
 {
 	void *data;
 	int len;
@@ -246,10 +256,10 @@ rpc_ucode_blob_to_ucv(uc_vm_t *vm, struct blob_attr *attr, bool table, const cha
 		return ucv_string_new(data);
 
 	case BLOBMSG_TYPE_ARRAY:
-		return rpc_ucode_blob_array_to_ucv(vm, data, len, false);
+		return rpc_ucode_blob_array_to_ucv(vm, data, len, false, depth + 1);
 
 	case BLOBMSG_TYPE_TABLE:
-		return rpc_ucode_blob_array_to_ucv(vm, data, len, true);
+		return rpc_ucode_blob_array_to_ucv(vm, data, len, true, depth + 1);
 
 	default:
 		return NULL;
@@ -314,7 +324,7 @@ rpc_ucode_validate_call_args(struct ubus_object *obj, const char *ubus_method_na
 		}
 	}
 
-	*res = rpc_ucode_blob_array_to_ucv(&script->vm, blob_data(msg), blob_len(msg), true);
+	*res = rpc_ucode_blob_array_to_ucv(&script->vm, blob_data(msg), blob_len(msg), true, 0);
 
 	return UBUS_STATUS_OK;
 


### PR DESCRIPTION
## Summary

This series fixes a number of security- and correctness-relevant bugs in
rpcd, found during a focused audit of the C code. Each issue is its own
self-contained commit describing the bug and the fix; there is no intended
change in behaviour for well-formed requests.

The audit was assisted by Claude (Anthropic). Every finding and patch was
manually reviewed and verified before inclusion, and the commits carry
`Assisted-by:` trailers following the kernel coding-assistants convention.

## Fixes

**Integer overflow of timeout values**
- `main`: validate the `-t` argument before scaling to milliseconds
- `uci`: clamp the apply/rollback timeout to avoid signed overflow that would
  fire the rollback timer immediately

**Session id generation**
- `session`: treat a short read of `/dev/urandom` as an error instead of
  silently deriving a session id from partially-zero (predictable) data

**`rc list` deferred-request handling** (the async init.d walk)
- free the per-request context (was leaked on every successful call)
- copy the `name` filter to avoid a use-after-free of the ubus receive buffer
- give each request its own `blob_buf` instead of a shared static one
- reap the SIGKILLed child on the "running"-check timeout to avoid a zombie

**`packagelist` (apk backend)**
- read `/etc/apk/world` into a buffer instead of mmap'ing one byte past a
  page-aligned file, which could fault with SIGBUS
- check the `calloc()` result for the world array
- guard against `size_t` underflow when stripping the ABI-version suffix
- close the status file on the world-parsing error paths

**Forked children**
- `_exit()` instead of returning a ubus status from a child that failed to
  set up or exec, so it can't unwind back into the dispatch loop and keep
  running as a duplicate rpcd (exec, file, sys, plugin)

**Other memory-safety / robustness**
- `exec`: reset pipe fds to -1 after closing them to prevent a double-close
  of a meanwhile-reused descriptor
- `plugin`: use `snprintf()` in the ubus lookup callback to bound the object
  path copy
- `ucode`: bound recursion when converting deeply nested blob arguments
  (attacker-controlled nesting could overflow the stack)
- `ucode`: fix an off-by-one that truncated generated ubus object type names
- `iwinfo`: fix error handling and a backend leak in `survey`
- `file`: don't emit uninitialized stack memory for a broken symlink target
- `file`: skip the zero-length `b64_decode()` on an empty write (it asserts
  in libubox)
- treewide: cast `char` to `unsigned char` for `ctype.h` calls on client- or
  file-controlled data (UB / possible out-of-bounds table read)